### PR TITLE
Add possibility to return the full operation data in addition to value

### DIFF
--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -5,8 +5,10 @@ class DocumentIndex {
     this._index = {}
   }
 
-  get(key) {
-    return this._index[key]
+  get(key, fullOp = false) {
+    return fullOp
+      ? this._index[key]
+      : this._index[key].payload.value
   }
 
   updateIndex(oplog, onProgressCallback) {
@@ -16,7 +18,7 @@ class DocumentIndex {
         // handled.push(item.payload.key)
         handled[item.payload.key] = true
         if(item.payload.op === 'PUT') {
-          this._index[item.payload.key] = item.payload.value
+          this._index[item.payload.key] = item
         } else if (item.payload.op === 'DEL') {
           delete this._index[item.payload.key]
         }

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -37,9 +37,12 @@ class DocumentStore extends Store {
       .map(mapper)
   }
 
-  query(mapper) {
+  query(mapper, options = {}) {
+    // Whether we return the full operation data or just the db value
+    const fullOp = options ? options.fullOp : false
+
     return Object.keys(this._index._index)
-      .map((e) => this._index.get(e))
+      .map((e) => this._index.get(e, fullOp))
       .filter((e) => mapper(e))
   }
 


### PR DESCRIPTION
This PR will add a flag to `.query()` to specify whether the full operation data should be returned instead of the value. Getting the full operation is useful when wanting to compare for example the clocks of entries or their parent-child relationship (eg. revision history).