### PR TITLE
Make sure to check that the entry exists when returning the payload

### DIFF
--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -8,7 +8,7 @@ class DocumentIndex {
   get (key, fullOp = false) {
     return fullOp
       ? this._index[key]
-      : this._index[key].payload.value
+      : this._index[key] ? this._index[key].payload.value : null
   }
 
   updateIndex (oplog, onProgressCallback) {


### PR DESCRIPTION
This PR will fix an error where, if the entry with `key` is not found the index, would throw an error. We now make sure that the entry exists and return null if it doesn't.