### PR TITLE
Proto/multi index and query

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ const docstore = orbitdb.docstore('db name', { indexBy: {first_name: 'string', a
 
 docstore.put({ first_name: 'Tyra', age: '35', occupation: 'Fashion Model' })
   .then(() => docstore.put({ first_name: 'Lindsay', age: 20, occupation: 'Student'}))
-  // [{ _id: 'hello universe', doc: 'all the things'}]
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ npm install orbit-db-docstore
 const IPFS = require('ipfs')
 const OrbitDB = require('orbit-db')
 
-const ipfs = new IPFS()
+const ipfs = new IPFS({
+  EXPERIMENTAL: {
+        pubsub: true,
+    }
+  })
 const orbitdb = new OrbitDB(ipfs)
 const docstore = orbitdb.docstore('db name')
 
@@ -30,30 +34,27 @@ docstore.put({ _id: 'hello world', doc: 'all the things' })
 
 ```
 
-You can specify the field to index by in the options:
+You can specify the fields to index by in the options:
 
 ```javascript
-const docstore = orbitdb.docstore('db name', { indexBy: 'doc' })
+const docstore = orbitdb.docstore('db name', { indexBy: {first_name: 'string', age: 'numeric'}} })
 
-docstore.put({ _id: 'hello world', doc: 'some things' })
-  .then(() => docstore.put({ _id: 'hello universe', doc: 'all the things' }))
-  .then(() => docstore.get('all'))
-  .then((value) => console.log(value)) 
+docstore.put({ first_name: 'Tyra', age: '35', occupation: 'Fashion Model' })
+  .then(() => docstore.put({ first_name: 'Lindsay', age: 20, occupation: 'Student'}))
   // [{ _id: 'hello universe', doc: 'all the things'}]
 
 ```
 
-You can also use a mapper to query the documents
+You can write a query to retrieve data
 
 ```javascript
 const docstore = orbitdb.docstore('db name')
 
-docstore.put({ _id: 'hello world', doc: 'some things', views: 10 })
-  .then(() => docstore.put({ _id: 'hello universe', doc: 'all the things', views: 100 }))
-  .then(() => docstore.put({ _id: 'sup world', doc: 'other things', views: 5 }))
-  .then(() => docstore.query((e)=> e.views > 5))
+docstore.put({ first_name: 'Tyra', age: 35, occupation: 'Fashion Model' })
+  .then(() => docstore.put({ first_name: 'Lindsay', age: 20, occupation: 'Student'}))
+  .then(() => docstore.query({first_name: 'Tyra'})
   .then((value) => console.log(value)) 
-  // [{ _id: 'hello world', doc: 'some things', views: 10}, { _id: 'hello universe', doc: 'all the things', views: 100}]
+  // [{ first_name: 'Tyra', age: 35, occupation: 'Fashion Model' }]
 ```
 
 ## API
@@ -66,36 +67,30 @@ docstore.put({ _id: 'hello world', doc: 'some things', views: 10 })
   [orbit-db-docstore](https://github.com/shamb0t/orbit-db-docstore)
 
   ```javascript
-  const db = orbitdb.docstore('orbit.users.shamb0t.profile')
+  const db = orbitdb.docstore('user_profile')
   ```
 
   By default, documents are indexed by field '_id'. You can also specify the field to index by:
 
   ```javascript
-  const db = orbitdb.docstore('orbit.users.shamb0t.profile', { indexBy: 'name' })
+  const db = orbitdb.docstore('orbit.users.shamb0t.profile', { indexBy: { name: 'string' } })
   ```
 
   - **put(doc)**
     ```javascript
-    db.put({ _id: 'QmAwesomeIpfsHash', name: 'shamb0t', followers: 500 }).then((hash) => ...)
+    db.put({ _id: 123456789, name: 'shamb0t', followers: 500 }).then((hash) => ...)
     ```
-    
-  - **get(key)**
+
+    ```    
+  - **query(queryObj)**
     ```javascript
-    const profile = db.get('shamb0t')
-      .map((e) => e.payload.value)
-    // [{ _id: 'shamb0t', name: 'shamb0t', followers: 500 }]
-    ```
-    
-  - **query(mapper)**
-    ```javascript
-    const all = db.query((doc) => doc.followers >= 500)
+    const all = db.query( { follower: 500 } )
     // [{ _id: 'shamb0t', name: 'shamb0t', followers: 500 }]
     ```
 
-  - **del(key)**
+  - **del(_id)**
     ```javascript
-    db.del('shamb0t').then((removed) => ...)
+    db.del(123456789).then((removed) => ...)
     ```
     
   - **events**

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "orbit-db-store": "~2.5.0",
-    "p-map": "~1.1.1"
+    "p-map": "~1.1.1",
+    "underscore": "^1.9.1"
   },
   "devDependencies": {},
   "repository": {

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -4,6 +4,7 @@ const Store = require('orbit-db-store')
 const DocumentIndex = require('./DocumentIndex')
 const pMap = require('p-map')
 const Readable = require('readable-stream')
+const _ = require('underscore')
 
 const replaceAll = (str, search, replacement) => str.toString().split(search).join(replacement)
 
@@ -31,27 +32,21 @@ class DocumentStore extends Store {
 
     // Expected input for indexBy is {indexBy: {field1: type1, field2: type2}}
     this._indexedFields = {}
+    this._indexes = {}
+    var self = this
     Object.keys(indexBy).forEach(function(index) {
-        this._indexedFields[index].type = options.indexBy[index]
-      })
+      self._indexes[index] = {}
+      self._indexedFields[index] = {}
+      self._indexedFields[index]['type'] = options.indexBy[index]
+    })
     this._type = 'docstore'
 
   }
 
-  get (key, caseSensitive = false) {
-    key = key.toString()
-    const terms = key.split(' ')
-    key = terms.length > 1 ? replaceAll(key, '.', ' ').toLowerCase() : key.toLowerCase()
-
-    const search = (e) => {
-      if (terms.length > 1) {
-        return replaceAll(e, '.', ' ').toLowerCase().indexOf(key) !== -1
-      }
-      return e.toLowerCase().indexOf(key) !== -1
-    }
+  get (_id, caseSensitive = false) {    
     const mapper = e => this._index.get(e)
     const filter = e => caseSensitive
-      ? e.indexOf(key) !== -1 
+      ? e.indexOf(_id) !== -1 
       : search(e)
 
     return Object.keys(this._index._index)
@@ -60,49 +55,56 @@ class DocumentStore extends Store {
   }
 
   query (queryObj, options = {}) {
+    var self = this
     // Whether we return the full operation data or just the db value
     // const fullOp = options ? options.fullOp : false
     var shortlisted_result = {}
     var unindexed_fields = []
+    var reduced_queryObj = {}
+
     Object.keys(queryObj).forEach(function(field) {
-      if (this._indexedFields[field]) {
+      if (self._indexedFields[field]) {
         var value_to_retrieve = queryObj[field]
-        if (!this._indexes[field][value_to_retrieve]){
+        if (!self._indexes[field][value_to_retrieve]){
           // if there's no matching value, return right away
           return []
         } else {
-          shortlisted_result[field] = this._indexes[field][value_to_retrieve]
+          shortlisted_result[field] = self._indexes[field][value_to_retrieve]
         }
         
       } else {
-        unindexed_fields.push(field)
+        reduced_queryObj[field] = queryObj[field]
       }
     });
-
-    var reduced_queryObj = {}
-    unindexed_fields.forEach(function(unindexed_field) {
-      reduced_queryObj[unindexed_field] = queryObj[unindexed_field]
-    })
-
-    // Consolidate shortlisted results to one final array
+    console.log(reduced_queryObj)
+    
+    
     var id_array_to_search = []
-    Object.keys(shortlisted_result).forEach(function(field) {
-      var current_field_array = shortlisted_result[field]
-      current_field_array.forEach(function(hash_value) {
-        if (!array_to_search.includes(hash_value)) {
-          array_to_search.push(hash_value)
+    if (JSON.stringify(queryObj) === JSON.stringify(reduced_queryObj)) {
+      // If the query contains no indexed field, scan the whole store
+      console.log("No indexed fields found in the query object, gotta scan the whole store")
+      id_array_to_search = Object.keys(self._index._index)
+    } else {
+      // If the query contains at least one indexed field,
+      // consolidate shortlisted results to one final array 
+      Object.keys(shortlisted_result).forEach(function(field) {
+        var current_field_array = shortlisted_result[field]
+        if (id_array_to_search.length == 0) {
+          id_array_to_search = current_field_array
+        } else {
+          id_array_to_search = _.intersection(id_array_to_search, current_field_array)
         }
+        
       })
-    })
+    }    
 
-    var array_to_search = []
-    id_array_to_search.map(e => array_to_search.push(this._index.get(e)))
-    console.log(array_to_search)
+    var record_array_to_search = []
+    id_array_to_search.map(e => record_array_to_search.push(this._index.get(e)))
 
     var value_to_search = []
     var results = []
     // Find matching records in shortlisted_results
-    array_to_search.forEach(function(record) {
+    record_array_to_search.forEach(function(record) {
       var matched = true
       for (var field in reduced_queryObj) {
         if (record[field] != reduced_queryObj[field]) {
@@ -111,12 +113,11 @@ class DocumentStore extends Store {
         }
       }
       if (matched == false)
-        continue
+        return
       else
         results.push(record)
       matched = true
     })
-
     return results
   }
 
@@ -139,55 +140,60 @@ class DocumentStore extends Store {
   }
 
   put (doc) {
+    var self = this
     // If there is no _id in the object, create one using the current timestamp
     // precise to the mili-secondth to make sure no two _id's are the same
     if (!doc['_id'])
       doc['_id'] = Date.getTime().toString()
 
     // Check if all indexed fields exists in the input object except for _id
-    Object.keys(this._indexedFields).forEach(function(index) {
+    Object.keys(self._indexedFields).forEach(function(index) {
       if (index != '_id' && !doc[index])
         throw new Error(`Field '${index}' doesn't exist in the object.`)
     });
     
     // Modifying the indexes with new document
-    Object.keys(this._indexedFields).forEach(function(index) {      
-      doc_value_to_index = doc[index]
-      if (!this._indexes[index][doc_value_to_index])
-        this._indexes[index][doc_value_to_index] = []
-      this._indexes[index][doc_value_to_index].push(doc._id)
+    Object.keys(self._indexedFields).forEach(function(index) {      
+      var doc_value_to_index = doc[index]
+      if (!self._indexes[index][doc_value_to_index])
+        self._indexes[index][doc_value_to_index] = []
+      self._indexes[index][doc_value_to_index].push(doc._id)
       
       // If the index type is numeric, update the max and min value
       // FUTURE DEV: index float values in ranges
-      if (this._indexedFields[index][type] == 'numeric') {
-        if (!this._indexedFields[index].min || !this._indexedFields[index].max) {
-          this._indexedFields[index].min = doc_value_to_index
-          this._indexedFields[index].max = doc_value_to_index
+      if (self._indexedFields[index].type == 'numeric') {
+        if (!self._indexedFields[index].min || !self._indexedFields[index].max) {
+          self._indexedFields[index].min = doc_value_to_index
+          self._indexedFields[index].max = doc_value_to_index
         } else {
-          if (doc_value_to_index < this._indexedFields[index].min)
-            this._indexedFields[index].min = doc_value_to_index
-          else if (doc_value_to_index > this._indexedFields[index].max)
-            this._indexedFields[index].max = doc_value_to_index
+          if (doc_value_to_index < self._indexedFields[index].min)
+            self._indexedFields[index].min = doc_value_to_index
+          else if (doc_value_to_index > self._indexedFields[index].max)
+            self._indexedFields[index].max = doc_value_to_index
         }        
       }
     })
 
-    return this._addOperation({
+    return self._addOperation({
       op: 'PUT',
       key: doc._id,
       value: doc
     })
   }
 
-  del (key) {
-    if (!this._index.get(key))
-      throw new Error(`No entry with key '${key}' in the database`)
+  del (_id) {
+    if (!this._index.get(_id))
+      throw new Error(`No entry with _id '${_id}' in the database`)
 
     return this._addOperation({
       op: 'DEL',
-      key: key,
+      key: _id,
       value: null
     })
+  }
+
+  getIndex() {
+    return this._indexedFields
   }
 }
 


### PR DESCRIPTION
Note about this PR:

1. Each record needs a distinctive `_id`. If there is no `_id` in the record, it will be created by using the current epoch time. 
2. Search index will be built with `put()` function. The search index is basically an object containing all the values of the indexed fields as keys and an array of `_id`s as value. If a query contains at least one indexed field, it will consult the search index object first in order to reduce the search space. Right now there are two types of search index allowed: 'string' or 'numeric'. If 'numeric' is used, it will store two more information about the field: `min` and `max`. This is for future development where inequality query is used.
3. Support query instead of using mapper: users can query the data by using a query object just like mongoDB: `db.query({first_name: 'Huy'})`. It will return all records having fields that match the query object. Right now, it only works with equality.

Future work:
1. Support range index for fields with float values. Right now, it may work, but no guarantee. And it's not space efficient if we index all the float  values.
2. More complicated query object: 
- Supporting range search on numeric fields, this will require an agreement on which query standard to follow. MongoDB can be a good reference point, the operators used will be `$bg` for 'larger than', `$lt` for 'less than', `$eq` for 'equals to', `$not` for 'not equals to', `$in` for 'in range'.
- Option: Sort returned values with an indicated field.
- Option: Only return certain fields instead of the whole object.

