### PR TITLE
Add `putAll()` function

### DIFF
--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -13,9 +13,20 @@ class DocumentIndex {
 
   updateIndex (oplog, onProgressCallback) {
     const reducer = (handled, item, idx) => {
-      if (handled[item.payload.key] !== true) {
+      if (item.payload.op === 'PUTALL') {
+        for (const doc of item.payload.docs) {
+          if (handled[doc.key] !== true) {
+            handled[doc.key] = true
+            this._index[doc.key] = {
+              op: item.payload.op,
+              key: doc.key,
+              value: doc.value
+            }
+          }
+        }
+      } else if (handled[item.payload.key] !== true) {
         handled[item.payload.key] = true
-        if(item.payload.op === 'PUT') {
+        if (item.payload.op === 'PUT') {
           this._index[item.payload.key] = item
         } else if (item.payload.op === 'DEL') {
           delete this._index[item.payload.key]

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -65,8 +65,7 @@ class DocumentStore extends Store {
   }
 
   put (doc, options = {}) {
-    if (!doc[this.options.indexBy])
-      throw new Error(`The provided document doesn't contain field '${this.options.indexBy}'`)
+    if (!doc[this.options.indexBy]) { throw new Error(`The provided document doesn't contain field '${this.options.indexBy}'`) }
 
     return this._addOperation({
       op: 'PUT',
@@ -75,9 +74,22 @@ class DocumentStore extends Store {
     }, options)
   }
 
+  putAll (docs, options = {}) {
+    if (!(Array.isArray(docs))) {
+      docs = [docs]
+    }
+    if (!(docs.every(d => d[this.options.indexBy]))) { throw new Error(`The provided document doesn't contain field '${this.options.indexBy}'`) }
+    return this._addOperation({
+      op: 'PUTALL',
+      docs: docs.map((value) => ({
+        key: value[this.options.indexBy],
+        value
+      }))
+    }, options)
+  }
+
   del (key, options = {}) {
-    if (!this._index.get(key))
-      throw new Error(`No entry with key '${key}' in the database`)
+    if (!this._index.get(key)) { throw new Error(`No entry with key '${key}' in the database`) }
 
     return this._addOperation({
       op: 'DEL',


### PR DESCRIPTION
When putting bulk amounts of documents, the oplog quickly grows unmanageable if every single document put generates a corresponding oplog `PUT` entry. This PR aims to fix this performance cost by batching large volumes of documents into a single `PUTALL` oplog entry.

put vs putall performance: https://gist.github.com/phillmac/155ed1eb232e75fda4a793e7672460fd

Includes some style fixes from `standard --fix`