### PR TITLE
PutAll() handling fix

### DIFF
--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -18,9 +18,11 @@ class DocumentIndex {
           if (handled[doc.key] !== true) {
             handled[doc.key] = true
             this._index[doc.key] = {
-              op: item.payload.op,
-              key: doc.key,
-              value: doc.value
+              payload: {
+                op: 'PUT',
+                key: doc.key,
+                value: doc.value
+              }
             }
           }
         }


### PR DESCRIPTION
PutAll() successfully adds the records to orbitdb, but they aren't added correctly to the index and can't be get()ed. This should fix that. Check the get() method above to understand the bug: It looks for the "paylod" value of a document but that isn't set correctly in the updateIndex() function. 