### PR TITLE
[perf] optimise docs index

### DIFF
--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -12,10 +12,13 @@ class DocumentIndex {
   }
 
   updateIndex (oplog, onProgressCallback) {
-    const reducer = (handled, item, idx) => {
-      if (item.payload.op === 'PUTALL' && item.payload.docs[Symbol.iterator]) {
+    const values = oplog.values
+    const handled = {}
+    for (let i = values.length - 1; i >= 0; i--) {
+      const item = values[i]
+      if (item.payload.op === 'PUTALL' && item.payload.docs && item.payload.docs[Symbol.iterator]) {
         for (const doc of item.payload.docs) {
-          if (doc && handled[doc.key] !== true) {
+          if (doc && !handled[doc.key]) {
             handled[doc.key] = true
             this._index[doc.key] = {
               payload: {
@@ -26,7 +29,7 @@ class DocumentIndex {
             }
           }
         }
-      } else if (handled[item.payload.key] !== true) {
+      } else if (!handled[item.payload.key]) {
         handled[item.payload.key] = true
         if (item.payload.op === 'PUT') {
           this._index[item.payload.key] = item
@@ -34,15 +37,10 @@ class DocumentIndex {
           delete this._index[item.payload.key]
         }
       }
-      if (onProgressCallback) onProgressCallback(item, idx)
-      return handled
-    }
-
-    oplog.values
-      .slice()
-      .reverse()
-      .reduce(reducer, {})
-  }
+      if (onProgressCallback) {
+        onProgressCallback(item, values.length - i)
+      }
+   }
 }
 
 module.exports = DocumentIndex


### PR DESCRIPTION
In the same spirit as: https://github.com/orbitdb/orbit-db-kvstore/pull/48

There was not the need for the optimisation on the `handled` object. So the optimisation gains will be less, but still this eliminates the need for a copy of the array and a subsequent reversal.