### PR TITLE
SET opcode

### DIFF
--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -13,13 +13,11 @@ class DocumentIndex {
 
   updateIndex (oplog, onProgressCallback) {
     const values = oplog.values
-    const handled = {}
       for (let i  = 0; i <= values.length -1; i++) {
       const item = values[i]
       if (item.payload.op === 'PUTALL' && item.payload.docs && item.payload.docs[Symbol.iterator]) {
         for (const doc of item.payload.docs) {
-          if (doc && !handled[doc.key]) {
-            handled[doc.key] = true
+          if (doc) {
             this._index[doc.key] = {
               payload: {
                 op: 'PUT',
@@ -29,8 +27,7 @@ class DocumentIndex {
             }
           }
         }
-      } else if (!handled[item.payload.key]) {
-        if (item.payload.op === 'PUT') {
+      } if (item.payload.op === 'PUT') {
           this._index[item.payload.key] = item
         } else if (item.payload.op === 'DEL') {
           delete this._index[item.payload.key]
@@ -39,7 +36,6 @@ class DocumentIndex {
             Object.assign(this._index[item.payload.key].payload.value,item.payload.value)
           }
         }
-      }
       if (onProgressCallback) {
         onProgressCallback(item, values.length - i)
       }

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -35,7 +35,7 @@ class DocumentIndex {
         } else if (item.payload.op === 'EDIT') {
           if (this._index[item.payload.key]) {
             const vals = this._index[item.payload.key].payload.value;
-            for (const elem in item.payload.value) if (elem in vals) vals[elem] = item.payload.value[elem]
+            for (const elem in item.payload.value) vals[elem] = item.payload.value[elem]
           }
         }
       }

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -36,7 +36,6 @@ class DocumentIndex {
           if (this._index[item.payload.key]) {
             const vals = this._index[item.payload.key].payload.value;
             for (const elem in item.payload.value) if (elem in vals) vals[elem] = item.payload.value[elem]
-            this._index[item.payload.key].value = vals
           }
         }
       }

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -33,7 +33,7 @@ class DocumentIndex {
         } else if (item.payload.op === 'DEL') {
           delete this._index[item.payload.key]
         } else if (item.payload.op === 'EDIT') {
-          if(this._index[item.payload.key]){
+          if (this._index[item.payload.key]) {
             const vals = this._index[item.payload.key].payload.value;
             for (const elem in item.payload.value) if (elem in vals) vals[elem] = item.payload.value[elem];
             this._index[item.payload.key].value = vals

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -35,7 +35,7 @@ class DocumentIndex {
         } else if (item.payload.op === 'EDIT') {
           if (this._index[item.payload.key]) {
             const vals = this._index[item.payload.key].payload.value;
-            for (const elem in item.payload.value) if (elem in vals) vals[elem] = item.payload.value[elem];
+            for (const elem in item.payload.value) if (elem in vals) vals[elem] = item.payload.value[elem]
             this._index[item.payload.key].value = vals
           }
         }

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -32,12 +32,17 @@ class DocumentIndex {
           this._index[item.payload.key] = item
         } else if (item.payload.op === 'DEL') {
           delete this._index[item.payload.key]
+        } else if (item.payload.op === 'EDIT') {
+          if(this._index[item.payload.key]){
+            const vals = this._index[item.payload.key].payload.value;
+            for (const elem in item.payload.value) if (elem in vals) vals[elem] = item.payload.value[elem];
+            this._index[item.payload.key].value = vals
+          }
         }
       }
       if (onProgressCallback) onProgressCallback(item, idx)
       return handled
     }
-
     oplog.values
       .slice()
       .reverse()

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -43,6 +43,7 @@ class DocumentIndex {
       if (onProgressCallback) onProgressCallback(item, idx)
       return handled
     }
+    
     oplog.values
       .slice()
       .reverse()

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -31,7 +31,7 @@ class DocumentIndex {
           this._index[item.payload.key] = item
         } else if (item.payload.op === 'DEL') {
           delete this._index[item.payload.key]
-        } else if (item.payload.op === 'EDIT') {
+        } else if (item.payload.op === 'SET') {
           if (this._index[item.payload.key]) {
             Object.assign(this._index[item.payload.key].payload.value,item.payload.value)
           }

--- a/src/DocumentIndex.js
+++ b/src/DocumentIndex.js
@@ -34,8 +34,7 @@ class DocumentIndex {
           delete this._index[item.payload.key]
         } else if (item.payload.op === 'EDIT') {
           if (this._index[item.payload.key]) {
-            const vals = this._index[item.payload.key].payload.value;
-            for (const elem in item.payload.value) vals[elem] = item.payload.value[elem]
+            Object.assign(this._index[item.payload.key].payload.value,item.payload.value)
           }
         }
       }

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -98,7 +98,7 @@ class DocumentStore extends Store {
     }, options)
   }
 
-  edit (key, options = {}, edits) {
+  edit (key, options = {}, edits = {}) {
     if (!this._index.get(key)) { throw new Error(`No entry with key '${key}' in the database`) }
       
     return this._addOperation({

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -98,7 +98,7 @@ class DocumentStore extends Store {
     }, options)
   }
 
-  edit (key, options = {}, edits = {}) {
+  edit (key, edits = {}, options = {}) {
     if (!this._index.get(key)) { throw new Error(`No entry with key '${key}' in the database`) }
       
     return this._addOperation({

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -97,6 +97,16 @@ class DocumentStore extends Store {
       value: null
     }, options)
   }
+
+  edit (key, options = {}, edits) {
+    if (!this._index.get(key)) { throw new Error(`No entry with key '${key}' in the database`) }
+      
+    return this._addOperation({
+      op: 'EDIT',
+      key: key,
+      value: edits
+    }, options)
+  }
 }
 
 module.exports = DocumentStore

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -98,11 +98,11 @@ class DocumentStore extends Store {
     }, options)
   }
 
-  edit (key, edits = {}, options = {}) {
+  SET (key, edits = {}, options = {}) {
     if (!this._index.get(key)) { throw new Error(`No entry with key '${key}' in the database`) }
       
     return this._addOperation({
-      op: 'EDIT',
+      op: 'SET',
       key: key,
       value: edits
     }, options)

--- a/src/DocumentStore.js
+++ b/src/DocumentStore.js
@@ -98,7 +98,7 @@ class DocumentStore extends Store {
     }, options)
   }
 
-  SET (key, edits = {}, options = {}) {
+  set (key, edits = {}, options = {}) {
     if (!this._index.get(key)) { throw new Error(`No entry with key '${key}' in the database`) }
       
     return this._addOperation({


### PR DESCRIPTION
This implements an SET opcode for docstores.
You specify a key, and edit parameters, so you can update certain values of a document. This could be useful for example if you have a document with many fields and you want to make a small change or toggle a setting without having to re-obtain and re-input all of the values in the whole document. 

Usage:
`await mydocstore.set(key, {"title":  "new title", "setting": true}`)

This removes the `handled` checking for going backwards, and checks through the oplog from oldest to newest, so I'm curious if people think that's a good idea or not.
Also implements the changes in #48, apart from those relating to the above.
